### PR TITLE
Support `#` comments

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,8 +26,8 @@ export const TrailingDefinitions = new Map<TrailingCommand, TrailingSymbol>([
 ])
 
 const leadingWhiteSpacesRegExp = /^(?<lead>\s*)/
-// https://regex101.com/r/Om2ioU/1
-const trailingCommentsRegExp = /(\S)\s*(?:(?:\/\/.*|(?:(\/\*)(?!.*\2).*\*\/)))*\s*$/
+// https://regex101.com/r/UGIyOX/1
+const trailingCommentsRegExp = /(\S)\s*(?:(?:#.*|\/\/.*|(?:(\/\*)(?!.*\2).*\*\/)))*\s*$/
 
 export function activate(context: ExtensionContext) {
   for (const [command, symbol] of TrailingDefinitions) {

--- a/src/tests/toggle.test.ts
+++ b/src/tests/toggle.test.ts
@@ -43,6 +43,10 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
         ['test /* ignore */', `test${symbol} /* ignore */`, 5],
         ['test /* do not ignore */ test', `test /* do not ignore */ test${symbol}`, 30],
         ['test /* do not ignore */ test // ignore', `test /* do not ignore */ test${symbol} // ignore`, 30],
+        ['test # ignore', `test${symbol} # ignore`, 5],
+        ['test     # ignore', `test${symbol}     # ignore`, 5],
+        ['\ttest # ignore', `\ttest${symbol} # ignore`, 6],
+        ['test # ignore # ignore\t', `test${symbol} # ignore # ignore\t`, 5],
       ]
 
       for (const [before, after, jumpPosition] of tests) {
@@ -216,6 +220,10 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
           test /* ignore */
           test /* do not ignore */ test
           test /* do not ignore */ test // ignore
+          test # ignore
+          test     # ignore
+            test # ignore
+          test # ignore # ignore
         `,
         async (document, editor, content) => {
           const positions = [
@@ -226,6 +234,10 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
             new Position(4, 3),
             new Position(5, 0),
             new Position(6, 1),
+            new Position(7, 0),
+            new Position(8, 2),
+            new Position(9, 7),
+            new Position(10, 4),
           ]
           editor.selections = getSelectionsFromPositions(positions)
 
@@ -241,6 +253,10 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
               test${symbol} /* ignore */
               test /* do not ignore */ test${symbol}
               test /* do not ignore */ test${symbol} // ignore
+              test${symbol} # ignore
+              test${symbol}     # ignore
+                test${symbol} # ignore
+              test${symbol} # ignore # ignore
             `
           )
           assertPositionsEqual(
@@ -254,6 +270,10 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
                   new Position(4, 5),
                   new Position(5, 30),
                   new Position(6, 30),
+                  new Position(7, 5),
+                  new Position(8, 5),
+                  new Position(9, 7),
+                  new Position(10, 5),
                 ]
               : positions
           )
@@ -272,6 +292,10 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
                   new Position(4, 4),
                   new Position(5, 29),
                   new Position(6, 29),
+                  new Position(7, 4),
+                  new Position(8, 4),
+                  new Position(9, 6),
+                  new Position(10, 4),
                 ]
               : positions
           )

--- a/src/tests/toggleWithNewline.test.ts
+++ b/src/tests/toggleWithNewline.test.ts
@@ -81,6 +81,10 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
         ['test /* ignore */', `test${symbol} /* ignore */\n`, 0, 4],
         ['test /* do not ignore */ test', `test /* do not ignore */ test${symbol}\n`, 0, 29],
         ['test /* do not ignore */ test // ignore', `test /* do not ignore */ test${symbol} // ignore\n`, 0, 29],
+        ['test # ignore', `test${symbol} # ignore\n`, 0, 4],
+        ['test     # ignore', `test${symbol}     # ignore\n`, 0, 4],
+        ['\ttest # ignore', `\ttest${symbol} # ignore\n\t`, 1, 5],
+        ['test # ignore # ignore\t', `test${symbol} # ignore # ignore\t\n`, 0, 4],
       ]
 
       for (const [before, after, firstJumpPosition, secondJumpPosition] of tests) {
@@ -756,6 +760,9 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
           test /* ignore */
           test /* do not ignore */ test
           test /* do not ignore */ test // ignore
+          test # ignore
+          test     # ignore
+          test # ignore # ignore
           test
         `,
         async (document, editor) => {
@@ -766,6 +773,9 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
             new Position(3, 3),
             new Position(4, 0),
             new Position(5, 1),
+            new Position(6, 0),
+            new Position(7, 2),
+            new Position(8, 4),
           ]
           editor.selections = getSelectionsFromPositions(positions)
 
@@ -786,6 +796,12 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
 
             test /* do not ignore */ test${symbol} // ignore
 
+            test${symbol} # ignore
+
+            test${symbol}     # ignore
+
+            test${symbol} # ignore # ignore
+
             test
           `
 
@@ -800,6 +816,9 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
                   new Position(7, 0),
                   new Position(9, 0),
                   new Position(11, 0),
+                  new Position(13, 0),
+                  new Position(15, 0),
+                  new Position(17, 0),
                 ]
               : positions
           )
@@ -819,6 +838,9 @@ function runTestsWithCommandAndSymbol(command: TrailingCommand, symbol: Trailing
                   new Position(6, 4),
                   new Position(8, 29),
                   new Position(10, 29),
+                  new Position(12, 4),
+                  new Position(14, 4),
+                  new Position(16, 4),
                 ]
               : positions
           )


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

Support detecting comments in languages where it's using a `#` character

In the long run it would probably be better to use VSCodium Intellisense detection of comments though - but that's outside my competence :sweat_smile: 